### PR TITLE
Kubernetes monitoring

### DIFF
--- a/kubernetes-monitoring/Nginx/Dockerfile
+++ b/kubernetes-monitoring/Nginx/Dockerfile
@@ -9,5 +9,5 @@ RUN chmod -R 777 /var/cache/* && chmod -R 777 /var/run/
 
 WORKDIR /app
 RUN chmod -R 777 /app
-USER otus
+#USER otus
 CMD /usr/sbin/nginx -g 'daemon off;'

--- a/kubernetes-monitoring/Nginx/Dockerfile
+++ b/kubernetes-monitoring/Nginx/Dockerfile
@@ -1,0 +1,13 @@
+FROM nginx:stable
+RUN groupadd --gid 1001 otus \
+  && useradd --uid 1001 -g root -G sudo --shell /bin/bash -m otus
+
+ADD conf.d /etc/nginx/conf.d
+ADD app /app
+RUN sed -i 's/user  nginx/user otus/' /etc/nginx/nginx.conf
+RUN chmod -R 777 /var/cache/* && chmod -R 777 /var/run/
+
+WORKDIR /app
+RUN chmod -R 777 /app
+USER otus
+CMD /usr/sbin/nginx -g 'daemon off;'

--- a/kubernetes-monitoring/Nginx/app/homework.html
+++ b/kubernetes-monitoring/Nginx/app/homework.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>HomeWORK!!!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>HOMEWORK</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>

--- a/kubernetes-monitoring/Nginx/app/index.html
+++ b/kubernetes-monitoring/Nginx/app/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Home WORK Otus!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Its work - OTUS!!!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>

--- a/kubernetes-monitoring/Nginx/conf.d/default.conf
+++ b/kubernetes-monitoring/Nginx/conf.d/default.conf
@@ -1,0 +1,19 @@
+server {
+    listen       8000;
+    server_name  localhost;
+
+    location / {
+        root   /app;
+    }
+    
+    location /basic_status {
+        stub_status on;
+        access_log off;
+        allow all;
+    #    deny all;
+    }    
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/kubernetes-monitoring/Readme.md
+++ b/kubernetes-monitoring/Readme.md
@@ -11,11 +11,17 @@ Red metod
 
 prometheus - федерация (жирный прометеус)
  кросс сервисная федерация
+ хранение метрик отдельные хранилища
+  - victoria Metrics
+  - Cotrex
+  - Thanos
+  - clickhouse ^_^
+  
 prometheus Thanos - sidecar (контейнер)
 
 у minio есть distributed mode - вроде это как раз к HA относится. 
-https://docs.min.io/docs/distributed-minio-quickstart-guide.html 
-- установка через зельм слайд 52 из 79 время 1:15
+- https://docs.min.io/docs/distributed-minio-quickstart-guide.html 
+- установка через хельм слайд 52 из 79 время 1:15
 загрузка дашбордов в графану 1:30  59 страница
 
 nodepinger дашборд в графане

--- a/kubernetes-monitoring/Readme.md
+++ b/kubernetes-monitoring/Readme.md
@@ -1,4 +1,17 @@
-
+Установка prometheus оператор:
+ - repo https://github.com/helm/charts/tree/master/stable/prometheus-operator
+ - helm repo update
+ - применение values.yaml
+   - helm install stable/prometheus-operator --wait -f ./values.yaml
+- запуск проекта
+  - установка оператора prometheus идем пить кофе, в миникб так и не поставилось, а вот в GKE потребовалось минут 10-15
+  - применяем deployment
+  - применяем service
+  - применяем service-monitor
+  - открываем графану ч.з. nginx kubectl apply -f ingress-grafana.yaml
+  - заходим на ресурс https://grafana.34.89.193.23.nip.io/
+  - импортируем стандартный дашборд nginx находится в папке проекта
+  - смотрим за стандартными метриками nginx
 Метрики и мониторинг
 HPA - horizontal pod Autoscaler
 
@@ -13,11 +26,14 @@ prometheus - федерация (жирный прометеус)
  кросс сервисная федерация
  хранение метрик отдельные хранилища
   - victoria Metrics
-  - Cotrex
-  - Thanos
+  - Cortrex
+  - Thanos (схема таноса стр. 44)
+   - prometheus Thanos - sidecar (контейнер) собирает и предает дальше метрики
   - clickhouse ^_^
-  
-prometheus Thanos - sidecar (контейнер)
+- deadmen switch - если не поступают метрики от промитеуса, прийдет уведомление, что прометеус не работает
+- перезапустить прометея с измененным конфигом 
+  - http://127.0.0.1:9090/-/reload
+
 
 у minio есть distributed mode - вроде это как раз к HA относится. 
 - https://docs.min.io/docs/distributed-minio-quickstart-guide.html 

--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name:  monitoring
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitoring
+  namespace: monitoring
+  labels:
+    app: nginx-test
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: monitoring
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: 
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        app: monitoring
+    spec:
+      containers:
+      - name: monitoring
+        image: atalabirchuk/otus:nginx_monitoring_v3
+        ports:
+          - name: nginx
+            containerPort: 8000
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+      - name: nginx-exporter
+        image: fish/nginx-exporter
+        args:
+          - -nginx.scrape_uri="http://127.0.0.1:8000/basic_status"
+        ports:
+          - name: nginx-exporter
+            containerPort: 9113

--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -43,7 +43,19 @@ spec:
       - name: nginx-exporter
         image: fish/nginx-exporter
         args:
-          - -nginx.scrape_uri="http://127.0.0.1:8000/basic_status"
+          - -nginx.scrape_uri=http://127.0.0.1:8000/basic_status
         ports:
           - name: nginx-exporter
             containerPort: 9113
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 9113
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 9113
+          initialDelaySeconds: 20
+          periodSeconds: 10

--- a/kubernetes-monitoring/ingress-grafana.yaml
+++ b/kubernetes-monitoring/ingress-grafana.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: grafana  
+  annotations:
+    certmanager.k8s.io/acme-challenge-type: http01
+    certmanager.k8s.io/cluster-issuer: letsencrypt-production
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  labels:
+    app: grafana
+spec:
+  rules:
+  - host: grafana.34.89.193.23.nip.io
+    http:
+      paths:
+      - backend:
+          serviceName: prometheus-operator-1580560390-grafana
+          servicePort: 80
+        path: /
+  tls:
+  - hosts:
+    - grafana.34.89.193.23.nip.io
+    secretName: grafana.34.89.193.23.nip.io
+status:
+  loadBalancer:
+    ingress:
+    - ip: 34.89.128.146

--- a/kubernetes-monitoring/ingress-nginx.yaml
+++ b/kubernetes-monitoring/ingress-nginx.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nginx-test
+  namespace: monitoring
+  annotations:
+    certmanager.k8s.io/acme-challenge-type: http01
+    certmanager.k8s.io/cluster-issuer: letsencrypt-production
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  labels:
+    app: nginx-test
+spec:
+  rules:
+  - host: nginx-test.34.89.193.23.nip.io
+    http:
+      paths:
+      - backend:
+          serviceName: nginx-test
+          servicePort: 80
+        path: /
+  tls:
+  - hosts:
+    - nginx-test.34.89.193.23.nip.io
+    secretName: nginx-test.34.89.193.23.nip.io
+status:
+  loadBalancer:
+    ingress:
+    - ip: 34.89.128.146

--- a/kubernetes-monitoring/ingress-prometheus.yaml
+++ b/kubernetes-monitoring/ingress-prometheus.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: prometheus  
+  annotations:
+    certmanager.k8s.io/acme-challenge-type: http01
+    certmanager.k8s.io/cluster-issuer: letsencrypt-production
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  labels:
+    app: prometheus
+spec:
+  rules:
+  - host: prometheus.34.89.193.23.nip.io
+    http:
+      paths:
+      - backend:
+          serviceName: prometheus-operator-158056-prometheus
+          servicePort: 9090
+        path: /
+  tls:
+  - hosts:
+    - prometheus.34.89.193.23.nip.io
+    secretName: prometheus.34.89.193.23.nip.io
+status:
+  loadBalancer:
+    ingress:
+    - ip: 34.89.128.146

--- a/kubernetes-monitoring/prometheus/nginx-dashboard.json
+++ b/kubernetes-monitoring/prometheus/nginx-dashboard.json
@@ -1,0 +1,507 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Nginx exporter metrics",
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "id": 25,
+    "iteration": 1580570069752,
+    "links": [],
+    "panels": [
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "decimals": 2,
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 3,
+        "isNew": true,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "max": true,
+          "min": true,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(nginx_connections_processed_total{stage=\"any\"}[5m])) by (stage)",
+            "hide": false,
+            "interval": "",
+            "intervalFactor": 10,
+            "legendFormat": "requests",
+            "metric": "",
+            "refId": "B",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Requests/sec",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": 0,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "decimals": 2,
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 7
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "isNew": true,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "max": true,
+          "min": true,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(nginx_connections_current) by (state)",
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "{{state}}",
+            "metric": "",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Connections",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": 0,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "decimals": 2,
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 14
+        },
+        "hiddenSeries": false,
+        "id": 1,
+        "isNew": true,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "max": true,
+          "min": true,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(nginx_connections_processed_total{stage!=\"any\"}[5m])) by (stage)",
+            "hide": false,
+            "interval": "",
+            "intervalFactor": 10,
+            "legendFormat": "{{stage}}",
+            "metric": "",
+            "refId": "B",
+            "step": 10
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Connections rate",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": 0,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 21
+        },
+        "hiddenSeries": false,
+        "id": 4,
+        "isNew": true,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "max": true,
+          "min": true,
+          "rightSide": true,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(rate(container_cpu_usage_seconds_total{name=~\"nginx\"}[5m])) / count(node_cpu_seconds_total{mode=\"system\"}) * 100",
+            "intervalFactor": 2,
+            "legendFormat": "nginx",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "CPU usage",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": "10s",
+    "schemaVersion": 21,
+    "style": "dark",
+    "tags": [
+      "nginx"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "10.16.1.28:9113",
+            "value": "10.16.1.28:9113"
+          },
+          "datasource": "Prometheus",
+          "definition": "label_values(nginx_up{job=\"nginx-test\"}, instance)",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "instance",
+          "options": [
+            {
+              "selected": true,
+              "text": "10.16.1.28:9113",
+              "value": "10.16.1.28:9113"
+            },
+            {
+              "selected": false,
+              "text": "10.16.4.8:9113",
+              "value": "10.16.4.8:9113"
+            },
+            {
+              "selected": false,
+              "text": "10.16.5.3:9113",
+              "value": "10.16.5.3:9113"
+            }
+          ],
+          "query": "label_values(nginx_up{job=\"nginx-test\"}, instance)",
+          "refresh": 0,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-15m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Nginx",
+    "uid": "P_2TUm8Zz",
+    "version": 2
+  }

--- a/kubernetes-monitoring/prometheus/values.yaml
+++ b/kubernetes-monitoring/prometheus/values.yaml
@@ -1,0 +1,15 @@
+prometheus:
+  prometheusSpec:
+    retention: 3d
+    ### Check this labels: kubectl get prometheus -o yaml -n monitoring
+    serviceMonitorNamespaceSelector: {} ### Namespace for ServiceMonitors select
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector: {} ### matchLabels for ServiceMonitors select
+    # serviceMonitorSelector:
+    # matchLabels:
+    # prometheus: kube-prometheus
+    # release: prometheus-cluster-monitoring
+  service:
+    nodePort: 31060
+grafana:
+  adminPassword: admin

--- a/kubernetes-monitoring/service-monitor.yaml
+++ b/kubernetes-monitoring/service-monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-test
+  namespace: monitoring
+  labels:
+    team: frontend
+spec:
+  selector:
+    matchLabels:
+      app: nginx-test
+  endpoints:
+  - port: nginx-exporter

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: nginx-test
 spec:
 #  clusterIP: 10.96.251.58
-  type: ClusterIP
+  type: NodePort
   ports:
    - name: monitoring
      protocol: TCP
@@ -17,5 +17,6 @@ spec:
      protocol: TCP
      port: 9113
      targetPort: 9113
+     nodePort: 30680
   selector:
     app: monitoring

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-test
+  namespace: monitoring
+  labels:
+    app: nginx-test
+spec:
+#  clusterIP: 10.96.251.58
+  type: ClusterIP
+  ports:
+   - name: monitoring
+     protocol: TCP
+     port: 80
+     targetPort: 8000
+   - name: nginx-exporter
+     protocol: TCP
+     port: 9113
+     targetPort: 9113
+  selector:
+    app: monitoring


### PR DESCRIPTION
# Выполнено ДЗ №8 Kubernetes-monitoring
 - [+] Основное ДЗ
 - [ ] Задание со * не было

## В процессе сделано: 
- Все
- prometheus-operator установлен с помощью helm-3

## Как запустить проект:
   - helm install stable/prometheus-operator --wait -f ./values.yaml
- запуск проекта
  - установка оператора prometheus идем пить кофе, в миникуб так и не поставилось, а вот в GKE потребовалось минут 10-15(пришлось заскейлить еще пару нод)
  - применяем deployment.yaml
  - применяем service.yaml
  - применяем service-monitor.yaml
  - открываем графану ч.з. ingress kubectl apply -f ingress-grafana.yaml
  - заходим на ресурс https://grafana.34.89.193.23.nip.io/ (admin/admin123)
  - импортируем кастомный дашборд nginx находится в папке проекта nginx-dashboard.json
  - выбираем дашборд nginx из всего списка дашбордов. получаем метрики

## PR checklist:
 - [+] Выставлен label с номером домашнего задания
График с графаны можно посмотреть тут http://i.imgur.com/njNnXcp.png возможно ссылка просуществует не долго.... 
![image](https://user-images.githubusercontent.com/59047793/73594422-70faaa80-451f-11ea-8a40-a3aa45e72986.png)
